### PR TITLE
- adding katharsis-wildfly-example

### DIFF
--- a/katharsis-wildfly-example/README.md
+++ b/katharsis-wildfly-example/README.md
@@ -1,0 +1,4 @@
+In order to run this example just
+> mvn clean install
+> mvn wildfly:run
+> to access the service point your browser to: http://localhost:8080/wildfly-example/rest/query/all

--- a/katharsis-wildfly-example/pom.xml
+++ b/katharsis-wildfly-example/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+       <groupId>io.katharsis</groupId>
+    	<artifactId>katharsis-examples</artifactId>
+    	<version>0.9.3-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>katharsis-wildfly-example</artifactId>
+    <packaging>war</packaging>
+    
+    <name>Katharsis Wildly Example</name>
+
+    <dependencies>
+        <dependency>  
+            <groupId>javax</groupId>    
+             <artifactId>javaee-web-api</artifactId>    
+             <version>7.0</version>  
+         </dependency> 
+        
+               
+    </dependencies>
+ 
+    <build>
+          
+        <finalName>${project.artifactId}</finalName>
+ 
+        <plugins>
+              
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>1.0.2.Final</version>
+                <!--configuration>
+                    <jvmArgs>-Xms2048m -Xmx4024m -XX:MaxPermSize=2024M -XX:PermSize=1512M -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y</jvmArgs>
+                </configuration-->
+            </plugin>
+             
+            
+        </plugins>
+    </build>
+ 
+ 
+    
+</project>
+

--- a/katharsis-wildfly-example/src/main/java/org/katharsis/wildfly/endpoints/api/QueryEndpointService.java
+++ b/katharsis-wildfly-example/src/main/java/org/katharsis/wildfly/endpoints/api/QueryEndpointService.java
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.katharsis.wildfly.endpoints.api;
+
+import java.io.Serializable;
+import javax.ejb.Local;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+/**
+ *
+ * @author grogdj
+ */
+@Local
+@Path("/query")
+public interface QueryEndpointService extends Serializable {
+
+    @GET
+    @Path("all")
+    @Produces({MediaType.APPLICATION_JSON})
+    Response getAll();
+    
+   
+
+}

--- a/katharsis-wildfly-example/src/main/java/org/katharsis/wildfly/endpoints/impl/QueryEndpointServiceImpl.java
+++ b/katharsis-wildfly-example/src/main/java/org/katharsis/wildfly/endpoints/impl/QueryEndpointServiceImpl.java
@@ -1,0 +1,73 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.katharsis.wildfly.endpoints.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import javax.ejb.Stateless;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+import javax.ws.rs.core.Response;
+
+import org.katharsis.wildfly.endpoints.api.QueryEndpointService;
+import org.katharsis.wildfly.model.User;
+
+/**
+ *
+ * @author grogdj
+ */
+@Stateless
+public class QueryEndpointServiceImpl implements QueryEndpointService {
+
+
+    private final static Logger log = Logger.getLogger(QueryEndpointServiceImpl.class.getName());
+
+    private List<User> users = new ArrayList<User>();
+
+    public QueryEndpointServiceImpl() {
+        List<String> interests = new ArrayList<String>();
+        interests.add("coding");
+        interests.add("art");
+        users.add(new User(1L, "grogdj@gmail.com", "grogdj", "grogj", "dj", interests));
+        users.add(new User(2L, "bot@gmail.com", "bot", "bot", "harry", interests));
+        users.add(new User(3L, "evilbot@gmail.com", "evilbot", "bot", "john", interests));
+    }
+
+    @Override
+    public Response getAll(){
+
+        
+        JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
+
+        for (User u : users) {
+            JsonObjectBuilder jsonUserObjectBuilder = createFullJsonUser(u);
+            jsonArrayBuilder.add(jsonUserObjectBuilder);
+        }
+        return Response.ok(jsonArrayBuilder.build().toString()).build();
+    }
+
+    private JsonObjectBuilder createFullJsonUser(User u) {
+        JsonObjectBuilder jsonObjBuilder = Json.createObjectBuilder();
+        jsonObjBuilder.add("userId", (u.getId() == null) ? "" : u.getId().toString());
+        
+        jsonObjBuilder.add("firstname", (u.getFirstname() == null) ? "" : u.getFirstname());
+        jsonObjBuilder.add("lastname", (u.getLastname() == null) ? "" : u.getLastname());
+        jsonObjBuilder.add("nickname", (u.getNickname() == null) ? "" : u.getNickname());
+        JsonArrayBuilder interestsJsonArrayBuilder = Json.createArrayBuilder();
+        for (String i : u.getInterests()) {
+            interestsJsonArrayBuilder.add(i);
+        }
+        jsonObjBuilder.add("interests", interestsJsonArrayBuilder);
+        return jsonObjBuilder;
+    }
+
+    
+    
+   
+
+}

--- a/katharsis-wildfly-example/src/main/java/org/katharsis/wildfly/model/User.java
+++ b/katharsis-wildfly-example/src/main/java/org/katharsis/wildfly/model/User.java
@@ -1,0 +1,99 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.katharsis.wildfly.model;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ *
+ * @author grogdj
+ */
+public class User implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+
+    private String email;
+
+    private String nickname;
+
+    private String firstname;
+
+    private String lastname;
+
+    private List<String> interests;
+
+    public User() {
+    }
+
+    public User(Long id, String email, String nickname, String firstname, String lastname, List<String> interests) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.firstname = firstname;
+        this.lastname = lastname;
+        this.interests = interests;
+    }
+    
+    
+    public User(String email) {
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public String getFirstname() {
+        return firstname;
+    }
+
+    public void setFirstname(String firstname) {
+        this.firstname = firstname;
+    }
+
+    public String getLastname() {
+        return lastname;
+    }
+
+    public void setLastname(String lastname) {
+        this.lastname = lastname;
+    }
+
+    public List<String> getInterests() {
+        return interests;
+    }
+
+    public void setInterests(List<String> interests) {
+        this.interests = interests;
+    }
+
+    
+    
+
+}

--- a/katharsis-wildfly-example/src/main/resources/META-INF/beans.xml
+++ b/katharsis-wildfly-example/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
+</beans>

--- a/katharsis-wildfly-example/src/main/resources/META-INF/jboss-all.xml
+++ b/katharsis-wildfly-example/src/main/resources/META-INF/jboss-all.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2012 JBoss Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<jboss xmlns="urn:jboss:1.0">
+  <weld xmlns="urn:jboss:weld:1.0" require-bean-descriptor="true" non-portable-mode="true"/>
+</jboss>

--- a/katharsis-wildfly-example/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/katharsis-wildfly-example/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<jboss-web> 
+    <context-root>wildfly-example</context-root>
+    <!--security-domain>security-quickstart</security-domain>
+    <disable-audit>true</disable-audit-->
+    <!--security-domain>java:/jaas/security-quickstart</security-domain--> 
+</jboss-web>

--- a/katharsis-wildfly-example/src/main/webapp/WEB-INF/web.xml
+++ b/katharsis-wildfly-example/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,40 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <!-- One of the way of activating REST Servises is adding these lines, the server is responsible for adding the corresponding servlet automatically. If the src folder, org.jboss.as.quickstarts.rshelloworld.HelloWorld class has the Annotations to receive REST invocation-->
+    <servlet-mapping>
+        <servlet-name>javax.ws.rs.core.Application</servlet-name>
+        <url-pattern>/rest/*</url-pattern>
+    </servlet-mapping>
+    
+    <servlet-mapping>
+        <servlet-name>default</servlet-name>
+        <url-pattern>*.js</url-pattern>
+        <url-pattern>*.css</url-pattern>
+        <url-pattern>*.ico</url-pattern>
+        <url-pattern>*.png</url-pattern>
+        <url-pattern>*.jpg</url-pattern>
+        <url-pattern>*.htc</url-pattern>
+        <url-pattern>*.gif</url-pattern>
+    </servlet-mapping>
+    
+    <context-param>
+        <param-name>resteasy.providers</param-name>
+    </context-param>
+</web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
         <module>dropwizard-mongo-example</module>
         <module>jersey-example</module>
         <module>dropwizard-simple-example</module>
+        <module>katharsis-wildfly-example</module>
     </modules>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Here is a simple wildfly example. Look at the README.md file to run it and to see the json returned. 
This examples is using the javax.json.Json; javax.json.JsonArrayBuilder; javax.json.JsonObjectBuilder; packages. The main idea is to migrate this example to use katharsis and to return json with the jsonapi.org correct syntax and semantics. 