### PR TITLE
Adding commons-beanutils dep in dropwizard-mongo-example pom; the dep…

### DIFF
--- a/dropwizard-mongo-example/pom.xml
+++ b/dropwizard-mongo-example/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <morphia.version>0.111</morphia.version>
         <mongo-driver.version>2.13.0</mongo-driver.version>
+        <commons-beantuils.version>1.9.2</commons-beantuils.version>
     </properties>
 
     <dependencies>
@@ -43,6 +44,11 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
             <version>${mongo-driver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>${commons-beantuils.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
… was used transitively before through katharsis-core; it isn't any more as of #62, so adding the dep in that module pom to fix compilation error