### PR TITLE
fixed url of the example curl execution in the README

### DIFF
--- a/spring-boot-simple-example/README.md
+++ b/spring-boot-simple-example/README.md
@@ -6,5 +6,5 @@
 
 ## How to test with curl
 
-    $ curl -v http://localhost:8080/tasks/
+    $ curl -v http://localhost:8080/api/tasks/
     ...


### PR DESCRIPTION
The examples in the README file didn't work so I fixed them.