### PR TITLE
Fix: Remove slash at the end of APPLICATION_URL

### DIFF
--- a/jersey-example/src/main/java/io/katharsis/example/jersey/JerseyApplication.java
+++ b/jersey-example/src/main/java/io/katharsis/example/jersey/JerseyApplication.java
@@ -13,7 +13,7 @@ import javax.ws.rs.ApplicationPath;
 @ApplicationPath("/")
 public class JerseyApplication extends ResourceConfig {
 
-    public static final String APPLICATION_URL = "http://localhost:8080/";
+    public static final String APPLICATION_URL = "http://localhost:8080";
 
     public JerseyApplication() {
         property(KatharsisProperties.RESOURCE_SEARCH_PACKAGE, "io.katharsis.example.jersey.domain");


### PR DESCRIPTION
This corrects an issue when trying to navigate links.